### PR TITLE
Monotonic host time support

### DIFF
--- a/example/30-ublox.rules
+++ b/example/30-ublox.rules
@@ -1,1 +1,4 @@
-SUBSYSTEM=="tty", KERNEL=="ttyACM*", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0424", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1546", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0424", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1546", MODE="0666"

--- a/ubx_logger.py
+++ b/ubx_logger.py
@@ -6,6 +6,7 @@ from ubxtranslator.ubxtranslator.predefined import NAV_CLS
 from pandas import Timestamp, Timedelta # Use pandas time objects for nanosecond precision
 import os
 import threading
+import time
 
 
 parser = argparse.ArgumentParser(description="Log UBX-NAV-* messages from device to JSONL file")
@@ -50,7 +51,8 @@ def run(args):
                     raw = parseUBX(payload)
                     entry = {
                         "type": msg_name,
-                        "payload": raw
+                        "payload": raw,
+                        "monoTime": time.monotonic()
                     }
                     writer.write(json.dumps(entry) + "\n")
                 except (ValueError, IOError) as err:


### PR DESCRIPTION
Adds support to record monotonic time of the host machine in addition to GPS time. This allows for approximate sync with other recordings using same host time.