### PR TITLE
Update ubx_stdout.py (fix accuracy in JSON format)

### DIFF
--- a/ubx_stdout.py
+++ b/ubx_stdout.py
@@ -29,7 +29,7 @@ def outputSolution(solution, asJson = False):
             "longitude": measurement["lon"],
             "altitude": measurement["altitude"],
             "monotonicTime":  measurement["time"],
-            "accuracy": measurement["altitude"],
+            "accuracy": measurement["accuracy"],
             "verticalAccuracy": measurement["verticalAccuracy"]
         })
     else:


### PR DESCRIPTION
Prior to changes the script printed altitude as the accuracy when using JSON format.

Now it prints accuracy as it's supposed to.